### PR TITLE
Add option to save partial results

### DIFF
--- a/src/scenicplus/wrappers/run_pycistarget.py
+++ b/src/scenicplus/wrappers/run_pycistarget.py
@@ -276,7 +276,7 @@ def run_pycistarget(region_sets: Dict[str, pr.PyRanges],
                 for x in menr['DEM_'+key+'_No_promoters'].motif_enrichment.keys():
                     out_file = os.path.join(out_folder, str(x) +'.html')
                     menr['DEM_'+key+'_No_promoters'].motif_enrichment[str(x)].to_html(open(out_file, 'w'), escape=False, col_space=80)
-              if(save_partial):
+                if(save_partial):
                     with open(os.path.join(save_path, 'DEM_'+key+'_No_promoters'+'.pkl'), 'wb') as f:
                       dill.dump(menr['DEM_'+key+'_All'], f, protocol=-1)
                     


### PR DESCRIPTION
Added the argument `save_partial=False` which allows to save the results of the individual analyses before the final menr.
Useful to add new settings later on (or that the analysis crashes, which is the issue that I am having right now :P )

Feel free to decide whether to add it to the main branch or not...