### PR TITLE
Add option to compute region-gene distance relative to TSS instead of gene body

### DIFF
--- a/src/scenicplus/enhancer_to_gene.py
+++ b/src/scenicplus/enhancer_to_gene.py
@@ -111,7 +111,8 @@ def get_search_space(SCENICPLUS_obj: SCENICPLUS,
                      biomart_host='http://www.ensembl.org',
                      inplace=True,
                      key_added='search_space',
-                     implode_entries=True):
+                     implode_entries=True,
+                     extend_from_TSS=False):
     """
     Get search space surrounding genes to calculate enhancer to gene links
 
@@ -393,7 +394,13 @@ def get_search_space(SCENICPLUS_obj: SCENICPLUS,
                              'Gene_size_weight']].drop_duplicate_positions().copy()
         annot_nodup = pr.PyRanges(
             annot_nodup.df.drop_duplicates(subset="Gene", keep="first"))
-        extended_annot = extend_pyranges(annot, upstream[1], downstream[1])
+        if extend_from_TSS:
+            tmp_annot = annot.copy()
+            tmp_annot.Start = tmp_annot.Transcription_Start_Site.astype(np.int32)
+            tmp_annot.End = (tmp_annot.Transcription_Start_Site + 1).astype(np.int32)
+            extended_annot = extend_pyranges(tmp_annot, upstream[1], downstream[1])
+        else:
+            extended_annot = extend_pyranges(annot, upstream[1], downstream[1])
         extended_annot = extended_annot[[
             'Chromosome', 'Start', 'End', 'Strand', 'Gene', 'Gene_width', 'Gene_size_weight']]
 


### PR DESCRIPTION
If I understand the code correctly, the distances of regions (putative enhancers) to genes are computed relative to the gene body. Given that the enhancer must interact with the promoter, one could also add a parameter to the "get_search_space" function to compute these distances relative to the TSS.
I created the pull request to show more clearly what I mean. 