### PR TITLE
Bug fix scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ ray
 attr
 typing
 matplotlib
-sklearn
+scikit-learn
 statistics
 pyranges
 scipy


### PR DESCRIPTION
As referred in Issue #110 
This fix should solve the broken dependency as mentioned in the [scikit-learn github page](https://github.com/scikit-learn/sklearn-pypi-package)