### PR TITLE
Fixing_installation_issue_python_version_fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,7 @@ $ pip install .
 ## References
 
 [Bravo Gonzalez-Blas, C. & De Winter, S. *et al.* (2022). SCENIC+: single-cell multiomic inference of enhancers and gene regulatory networks](https://www.biorxiv.org/content/10.1101/2022.08.19.504505v1)
+
+## license
+
+The SCENIC+ [license](https://github.com/aertslab/scenicplus/blob/main/LICENCE.txt) covers [SCENIC+](https://github.com/aertslab/scenicplus), [pycisTarget](https://github.com/aertslab/pycistarget), [pycisTopic](https://github.com/aertslab/pycisTopic) and the [cisTarget dabases](https://resources.aertslab.org/cistarget/).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 description = "SCENIC+ is a python package to build gene regulatory networks (GRNs) using combined or separate single-cell gene expression (scRNA-seq) and single-cell chromatin accessibility (scATAC-seq) data."
 readme = "README.md"
 version = "1.0a2"
-requires-python = ">=3.8,<=3.11.8"
+requires-python = ">=3.8,<=3.11.11"
 keywords = ["scATAC", "GRN inference", "eGRN inference"]
 license = { file = "LICENCE.txt" }
 classifiers = [


### PR DESCRIPTION
The development branch of scenicplus appears to assume Python 3.11.11, despite the default pyproject.toml rejecting it.
To resolve this, I updated the requires-python field:
pyproject.toml, line 14
`requires-python = ">=3.8,<=3.11.11"`

