### PR TITLE
Add pixi install instructions [ac]

### DIFF
--- a/pixi-install/README.md
+++ b/pixi-install/README.md
@@ -1,0 +1,39 @@
+# SCENIC+ Environment Setup Using Pixi
+To support some of the installation issues, here's a method that uses a prebuilt pixi.toml file to set up the SCENIC+ environment and address build conflicts. The best way to do this would be in a new, blank conda instance or IDE with no other packages pre-installed. 
+
+## Prerequisites
+Install [pixi](https://pixi.sh):
+```bash
+curl -fsSL https://pixi.sh/install.sh | bash
+```
+
+## Install 
+```bash
+git clone https://github.com/aichander/scenicplus.git
+cd scenicplus
+git checkout pixi-install
+cd pixi-install
+pixi install
+pixi run setup
+```
+
+## Usage
+**CLI:**
+```bash
+pixi shell
+scenicplus
+```
+
+**Jupyter notebook:**  
+Run the kernel build pixi task 
+```bash
+pixi run kernel
+```
+Launch JupyterLab and select the **SCENIC+** kernel.
+
+## Uninstall
+
+```bash
+jupyter kernelspec uninstall scenicplus
+rm -rf scenicplus-env
+```

--- a/pixi-install/README.md
+++ b/pixi-install/README.md
@@ -8,7 +8,8 @@ curl -fsSL https://pixi.sh/install.sh | bash
 ```
 
 ## Install 
-Currently, the setup task is defined to pull the `main` branch of the Aerts Lab Scenic + github (https://github.com/aertslab/scenicplus.git)
+Currently, the setup task is defined to pull the `main` branch of the [Aerts Lab Scenic+ github](https://github.com/aertslab/scenicplus.git).
+
 ```bash
 git clone https://github.com/aichander/scenicplus.git
 cd scenicplus

--- a/pixi-install/README.md
+++ b/pixi-install/README.md
@@ -8,6 +8,7 @@ curl -fsSL https://pixi.sh/install.sh | bash
 ```
 
 ## Install 
+Currently, the setup task is defined to pull the `main` branch of the Aerts Lab Scenic + github (https://github.com/aertslab/scenicplus.git)
 ```bash
 git clone https://github.com/aichander/scenicplus.git
 cd scenicplus

--- a/pixi-install/pixi.toml
+++ b/pixi-install/pixi.toml
@@ -1,0 +1,19 @@
+[workspace]
+authors = ["Aishwarya Chander <aishwarya.chander@alleninstitute.org>"]
+channels = ["conda-forge", "bioconda"]
+name = "scenicplus-env"
+platforms = ["linux-64"]
+version = "0.1.0"
+
+[tasks]
+setup = "pip install --no-build-isolation pybedtools==0.9.1 && pip install git+https://github.com/aertslab/scenicplus.git@main && pip install ipykernel"
+kernel = "python -m ipykernel install --user --name scenicplus --display-name 'Python (SCENIC+)'"
+
+[dependencies]
+python = "3.11.8.*"
+pip = ">=26.1.1,<27"
+setuptools = "<70"
+cython = ">=3.2.4,<4"
+bedtools = ">=2.31.1,<3"
+htslib = ">=1.23.1,<2"
+pysam = ">=0.24.0,<0.25"


### PR DESCRIPTION
I added some brief instructions on package set up and installation using Pixi. If someone could rerun a tutorial and verify this method of installation works, it would make package setup much easier. 
To add any other packages, simply run ```pixi add <package-name>``` and the pixi.toml  + pixi.lock file will automatically update.